### PR TITLE
fix DisplayArea config option

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -98,7 +98,7 @@ if #Config.UsablePositions > 0 then
     end)
 end
 
-if Config.DataHeists.Enabled then
+if Config.DataHeists.Enabled and Config.DataHeists.DisplayArea then
     CreateThread(function()
         for coords, radius in pairs(Config.DataHeists.Areas) do
             local area = AddBlipForRadius(coords.x, coords.y, coords.z, radius + 0.0)


### PR DESCRIPTION
Config.DataHeists.DisplayArea wasn't being used to enable/disable the display of the heist blips.

This adds a check for the boolean and runs the blip creation thread if it is true.